### PR TITLE
fix : enable error_log for pool www

### DIFF
--- a/layers/layer1_php/0010_php/Makefile.mk
+++ b/layers/layer1_php/0010_php/Makefile.mk
@@ -28,6 +28,8 @@ $(PREFIX)/bin/php:
 	sed -i 's/^listen = .*/listen = {{PHP_SOCKET_PATH}}/g' $(PREFIX)/etc/php-fpm.d/www.conf
 	sed -i 's/^;listen.owner = .*/listen.owner = {{MFMODULE_RUNTIME_USER}}/g' $(PREFIX)/etc/php-fpm.d/www.conf
 	sed -i 's/^;listen.group = .*/listen.group = {{MFMODULE_RUNTIME_GROUP}}/g' $(PREFIX)/etc/php-fpm.d/www.conf
+	sed -i 's/^;php_admin_value[error_log] = .*/php_admin_value[error_log] = {{PHP_LOGFILE_PATH}}/g' $(PREFIX)/etc/php-fpm.d/www.conf
+	sed -i 's/^;php_admin_flag[log_errors] = .*/php_admin_flag[log_errors] = on/g' $(PREFIX)/etc/php-fpm.d/www.conf
 	sed -i 's/^;listen.mode = .*/listen.mode = 0660/g' $(PREFIX)/etc/php-fpm.d/www.conf
 	sed -i 's/^;clear_env = no/clear_env = no/g' $(PREFIX)/etc/php-fpm.d/www.conf
 	sed -i 's/%{%Y-%m-%dT%H:%M:%S%z}/{% raw %}%{%Y-%m-%dT%H:%M:%S%z}{% endraw %}/g' $(PREFIX)/etc/php-fpm.d/www.conf


### PR DESCRIPTION
By default in php.fpm.d/www.conf, error_log is disable.

Make it enable to be used in php scripts by log php frameworks such as Monolog...